### PR TITLE
Fix pagination

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -71,4 +71,4 @@ sass:
   sass_dir: _sass
   style: :compressed
 
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]


### PR DESCRIPTION
Looks like the key for plugins is incorrect and defined as `gems`.

During `composer up`, you'll get the error saying that it looks like you're using pagination - but haven't defined the plugin. This will resolve the issue and fix pagination on the homepage.